### PR TITLE
付箋編集ウィンドウに現在の付箋の色を反映するようにした

### DIFF
--- a/app/views/fusens/_form.html.erb
+++ b/app/views/fusens/_form.html.erb
@@ -17,9 +17,19 @@
   
   <div class="field">
     <select class="form-control" id="boxcolor" name="fusen[color]">
-      <option value="boxblue">blue</option>
-      <option value="boxyellow" selected="selected">yellow</option>
-      <option value="boxred">red</option>
+      <% if fusen.color == "boxblue" %>
+        <option value="boxblue" selected="selected">blue</option>
+        <option value="boxyellow" >yellow</option>
+        <option value="boxred">red</option>
+      <% elsif fusen.color == "boxyellow" then %>
+        <option value="boxblue">blue</option>
+        <option value="boxyellow" selected="selected">yellow</option>
+        <option value="boxred">red</option>
+      <% elsif fusen.color == "boxred" then %>
+        <option value="boxblue">blue</option>
+        <option value="boxyellow" >yellow</option>
+        <option value="boxred" selected="selected">red</option>
+      <% end %>
    </select> 
   </div>
 


### PR DESCRIPTION
付箋編集ボタンをクリックした時に、編集ウィンドウの付箋色選択ボックスに、
現在の付箋の色を反映するようにした。