### PR TITLE
new fusen選択時に色が選択できなくなる不具合を修正

### DIFF
--- a/app/views/fusens/_form.html.erb
+++ b/app/views/fusens/_form.html.erb
@@ -29,6 +29,10 @@
         <option value="boxblue">blue</option>
         <option value="boxyellow" >yellow</option>
         <option value="boxred" selected="selected">red</option>
+      <% else %>
+        <option value="boxblue">blue</option>
+        <option value="boxyellow" selected="selected">yellow</option>
+        <option value="boxred">red</option>
       <% end %>
    </select> 
   </div>


### PR DESCRIPTION
new fusen選択時に色が選択できないようになっていたので、
new fusen選択時に付箋色をyellowがデフォルトになるようにした。
