### PR TITLE
Docker-composeでDBコンテナも起動できるようにした

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,8 @@ RUN \
   cp ~/.gemrc /etc/gemrc && \
   chmod uog+r /etc/gemrc && \
   bundle install && \
-  rake db:migrate && \
   rm -rf ~/.gem
 
 EXPOSE  3000
-CMD ["rails", "server", "-b", "0.0.0.0"]
+CMD ["/usr/src/webclipboard/migrate.sh"]
 

--- a/README.md
+++ b/README.md
@@ -9,12 +9,14 @@ Webブラウザで付箋をペタペタ貼れるアプリです。
 
 # Install
 それぞれの手順でインストール後に、Webブラウザで3000ポートにアクセスすると、利用できるようになります。
+DBはPostgresを使っています。Docker-compose以外で起動する場合は、PostgreSQLが動いているサーバが必要になります。
 
 ## local install
 ```
  $ git clone https://github.com/kazu20/webclipboard.git
  $ cd webclipboard
  $ bundle install
+ $ export DB_HOST=PostgreSQL_Server_Name
  $ rake db:migrate
  $ rails s
 ```
@@ -26,12 +28,12 @@ Webブラウザで付箋をペタペタ貼れるアプリです。
  $ vagrant up
 ```
 
-## Docker
+## Docker-compose
 ```
  $ git clone https://github.com/kazu20/webclipboard.git
  $ cd webclipboard
  $ docker build -t username/imagename .
- $ docker run -d -p 3000:3000 username/imagename
+ $ docker-compose up -d 
 ```
 
 ![login image](https://github.com/kazu20/webclipboard/blob/master/images/login.png)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '2'
+
+services:
+  db:
+    restart: always
+    image: postgres
+    ports:
+      - "5432:5432"
+
+  app:
+    restart: always
+    image: kazu20/webclipboard_compose
+    command: [/usr/src/webclipboard/migrate.sh]
+    ports:
+      - "3000:3000"
+    depends_on:
+      - db
+    environment:
+      - DB_HOST=db

--- a/migrate.sh
+++ b/migrate.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+rake db:create
+rake db:migrate
+
+rails s -b 0.0.0.0
+


### PR DESCRIPTION
docker-composeでDBとfusenを起動できるようにした。
fusenはデフォルトDBがPostgreSQLになったので、
docker-compose以外で起動する場合は、自前でPostgreSQLを立てる必要がある。